### PR TITLE
st1 [2195][IMP] purchase_order_secondary_unit : Allow subunits to be used when receipt.

### DIFF
--- a/purchase_order_secondary_unit/i18n/ja.po
+++ b/purchase_order_secondary_unit/i18n/ja.po
@@ -1,0 +1,43 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* purchase_order_secondary_unit
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 12.0\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2021-12-28 04:39+0000\n"
+"Last-Translator: kakurai8 <ai@quartile.co>\n"
+"Language-Team: none\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate 4.3.2\n"
+
+#. module: purchase_order_secondary_unit
+#: model:ir.model.fields,field_description:purchase_order_secondary_unit.field_product_product__purchase_secondary_uom_id
+#: model:ir.model.fields,field_description:purchase_order_secondary_unit.field_product_template__purchase_secondary_uom_id
+msgid "Default unit purchase"
+msgstr "購入時のデフォルトの副単位"
+
+#. module: purchase_order_secondary_unit
+#: model:ir.model,name:purchase_order_secondary_unit.model_product_template
+msgid "Product Template"
+msgstr "プロダクトテンプレート"
+
+#. module: purchase_order_secondary_unit
+#: model:ir.model,name:purchase_order_secondary_unit.model_purchase_order_line
+msgid "Purchase Order Line"
+msgstr "購買オーダ明細"
+
+#. module: purchase_order_secondary_unit
+#: model:ir.model.fields,field_description:purchase_order_secondary_unit.field_purchase_order_line__secondary_uom_qty
+msgid "Secondary Qty"
+msgstr "数量(副単位)"
+
+#. module: purchase_order_secondary_unit
+#: model:ir.model.fields,field_description:purchase_order_secondary_unit.field_purchase_order_line__secondary_uom_id
+msgid "Secondary uom"
+msgstr "副単位"


### PR DESCRIPTION
[2195](https://www.quartile.co/web#id=2195&model=project.task&view_type=form&menu_id=)

done:
- update to the latest version

not yet:
- ①入荷オーダの「数量(副単位)」、「Second Unit」双方とも0、NULL状態でPOの値が反映させる
- ②入荷オーダの詳細オペレーションで入荷数を編集時に、
「数量(副単位)」、「Second Unit」を更新しても完了数に反映させる
