### PR TITLE
st1 [2195][IMP] stock_secondary_unit: update to the latest version

### DIFF
--- a/stock_secondary_unit/README.rst
+++ b/stock_secondary_unit/README.rst
@@ -69,6 +69,7 @@ Contributors
 * Carlos Dauden <carlos.dauden@tecnativa.com>
 * Sergio Teruel <sergio.teruel@tecnativa.com>
 * Kitti Upariphutthiphong <kittiu@ecosoft.co.th>
+* Giovanni Serra <giovanni@gslab.it>
 
 Maintainers
 ~~~~~~~~~~~

--- a/stock_secondary_unit/__manifest__.py
+++ b/stock_secondary_unit/__manifest__.py
@@ -3,7 +3,7 @@
 {
     'name': 'Stock Secondary Unit',
     'summary': 'Get product quantities in a secondary unit',
-    'version': '12.0.1.0.1',
+    'version': '12.0.1.2.2',
     'development_status': 'Beta',
     'category': 'stock',
     'website': 'https://github.com/OCA/stock-logistics-warehouse',

--- a/stock_secondary_unit/i18n/it.po
+++ b/stock_secondary_unit/i18n/it.po
@@ -1,32 +1,31 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# 	* stock_secondary_unit
+#	* stock_secondary_unit
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 11.0\n"
+"Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-11 06:27+0000\n"
-"PO-Revision-Date: 2018-09-11 08:28+0200\n"
-"Last-Translator: \n"
-"Language-Team: \n"
-"Language: es_ES\n"
+"PO-Revision-Date: 2020-03-16 20:13+0000\n"
+"Last-Translator: Francesco Foresti <francesco.foresti@ooops404.com>\n"
+"Language-Team: none\n"
+"Language: it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 2.0.6\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 3.10\n"
 
 #. module: stock_secondary_unit
 #: model_terms:ir.ui.view,arch_db:stock_secondary_unit.report_delivery_document
 msgid "<strong>Secondary Qty</strong>"
-msgstr ""
+msgstr "<strong>Qty Secondaria</strong>"
 
 #. module: stock_secondary_unit
 #: model:ir.model.fields,field_description:stock_secondary_unit.field_stock_product_secondary_unit__display_name
 #: model:ir.model.fields,field_description:stock_secondary_unit.field_stock_secondary_unit_mixin__display_name
 msgid "Display Name"
-msgstr "Mostrar Nombre"
+msgstr "Nome visualizzato"
 
 #. module: stock_secondary_unit
 #: model:ir.model.fields,field_description:stock_secondary_unit.field_stock_product_secondary_unit__id
@@ -38,76 +37,67 @@ msgstr "ID"
 #: model:ir.model.fields,field_description:stock_secondary_unit.field_stock_product_secondary_unit____last_update
 #: model:ir.model.fields,field_description:stock_secondary_unit.field_stock_secondary_unit_mixin____last_update
 msgid "Last Modified on"
-msgstr "Última modificación en"
+msgstr "Ultima modifica il"
 
 #. module: stock_secondary_unit
 #: model:ir.model,name:stock_secondary_unit.model_product_product
 msgid "Product"
-msgstr "Producto"
+msgstr "Prodotto"
 
 #. module: stock_secondary_unit
 #: model:ir.model,name:stock_secondary_unit.model_stock_move_line
 msgid "Product Moves (Stock Move Line)"
-msgstr ""
+msgstr "Movimentazioni prodotto (Riga Movimenti Magazzino)"
 
 #. module: stock_secondary_unit
 #: model:ir.model,name:stock_secondary_unit.model_product_template
 msgid "Product Template"
-msgstr "Plantilla de producto"
+msgstr "Modello Prodotto"
 
 #. module: stock_secondary_unit
 #: model:ir.model.fields,field_description:stock_secondary_unit.field_product_product__secondary_unit_qty_available
 #: model:ir.model.fields,field_description:stock_secondary_unit.field_product_template__secondary_unit_qty_available
 #: model:ir.model.fields,field_description:stock_secondary_unit.field_stock_product_secondary_unit__secondary_unit_qty_available
 msgid "Quantity On Hand (2Unit)"
-msgstr "Cantidad a mano (2Ud.)"
+msgstr "Quantità disponibile (Unità 2)"
 
 #. module: stock_secondary_unit
 #: model:ir.model.fields,field_description:stock_secondary_unit.field_stock_move__secondary_uom_id
 #: model:ir.model.fields,field_description:stock_secondary_unit.field_stock_move_line__secondary_uom_id
 #: model:ir.model.fields,field_description:stock_secondary_unit.field_stock_secondary_unit_mixin__secondary_uom_id
-#, fuzzy
 msgid "Second unit"
-msgstr "Unidad Secundaria"
+msgstr "Unità secondaria"
 
 #. module: stock_secondary_unit
 #: model:ir.model.fields,field_description:stock_secondary_unit.field_product_product__stock_secondary_uom_id
 #: model:ir.model.fields,field_description:stock_secondary_unit.field_product_template__stock_secondary_uom_id
 msgid "Second unit for inventory"
-msgstr "Segunda unidad de medida para inventario"
+msgstr "Unità secondaria per l'inventario"
 
 #. module: stock_secondary_unit
 #: model:ir.model.fields,field_description:stock_secondary_unit.field_stock_move__secondary_uom_qty
 #: model:ir.model.fields,field_description:stock_secondary_unit.field_stock_move_line__secondary_uom_qty
 #: model:ir.model.fields,field_description:stock_secondary_unit.field_stock_secondary_unit_mixin__secondary_uom_qty
-#, fuzzy
 msgid "Secondary Qty"
-msgstr "Unidad Secundaria"
+msgstr "Qty Secondaria"
 
 #. module: stock_secondary_unit
 #: model_terms:ir.ui.view,arch_db:stock_secondary_unit.view_template_property_form
 msgid "Secondary unit"
-msgstr "Unidad Secundaria"
+msgstr "Unità Secondaria"
 
 #. module: stock_secondary_unit
 #: model:ir.model,name:stock_secondary_unit.model_stock_move
 msgid "Stock Move"
-msgstr ""
+msgstr "Movimento di magazzino"
 
 #. module: stock_secondary_unit
 #: model:ir.model,name:stock_secondary_unit.model_stock_product_secondary_unit
-#, fuzzy
 msgid "Stock Product Secondary Unit"
-msgstr "Unidad Secundaria"
+msgstr "Prodotto Stock Unità Secondaria"
 
 #. module: stock_secondary_unit
 #: model:ir.model,name:stock_secondary_unit.model_stock_secondary_unit_mixin
 #, fuzzy
 msgid "Stock Secondary Unit Mixin"
-msgstr "Unidad Secundaria"
-
-#~ msgid "On Hand (2unit)"
-#~ msgstr "A mano (2Ud.)"
-
-#~ msgid "Second Unit Quantity On Hand"
-#~ msgstr "Segunda unidad de medida por defecto"
+msgstr "Unità Secondaria Stock Mixin"

--- a/stock_secondary_unit/i18n/zh_CN.po
+++ b/stock_secondary_unit/i18n/zh_CN.po
@@ -1,32 +1,31 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# 	* stock_secondary_unit
+#	* stock_secondary_unit
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 11.0\n"
+"Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-11 06:27+0000\n"
-"PO-Revision-Date: 2018-09-11 08:28+0200\n"
-"Last-Translator: \n"
-"Language-Team: \n"
-"Language: es_ES\n"
+"PO-Revision-Date: 2019-10-21 15:32+0000\n"
+"Last-Translator: Tony Gu <tony@openerp.cn>\n"
+"Language-Team: none\n"
+"Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 2.0.6\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate 3.8\n"
 
 #. module: stock_secondary_unit
 #: model_terms:ir.ui.view,arch_db:stock_secondary_unit.report_delivery_document
 msgid "<strong>Secondary Qty</strong>"
-msgstr ""
+msgstr "<strong> 辅助单位数量</strong>"
 
 #. module: stock_secondary_unit
 #: model:ir.model.fields,field_description:stock_secondary_unit.field_stock_product_secondary_unit__display_name
 #: model:ir.model.fields,field_description:stock_secondary_unit.field_stock_secondary_unit_mixin__display_name
 msgid "Display Name"
-msgstr "Mostrar Nombre"
+msgstr "显示名称"
 
 #. module: stock_secondary_unit
 #: model:ir.model.fields,field_description:stock_secondary_unit.field_stock_product_secondary_unit__id
@@ -38,76 +37,66 @@ msgstr "ID"
 #: model:ir.model.fields,field_description:stock_secondary_unit.field_stock_product_secondary_unit____last_update
 #: model:ir.model.fields,field_description:stock_secondary_unit.field_stock_secondary_unit_mixin____last_update
 msgid "Last Modified on"
-msgstr "Última modificación en"
+msgstr "最后修改时间"
 
 #. module: stock_secondary_unit
 #: model:ir.model,name:stock_secondary_unit.model_product_product
 msgid "Product"
-msgstr "Producto"
+msgstr "产品"
 
 #. module: stock_secondary_unit
 #: model:ir.model,name:stock_secondary_unit.model_stock_move_line
 msgid "Product Moves (Stock Move Line)"
-msgstr ""
+msgstr "产品移动（库存移动行）"
 
 #. module: stock_secondary_unit
 #: model:ir.model,name:stock_secondary_unit.model_product_template
 msgid "Product Template"
-msgstr "Plantilla de producto"
+msgstr "产品模板"
 
 #. module: stock_secondary_unit
 #: model:ir.model.fields,field_description:stock_secondary_unit.field_product_product__secondary_unit_qty_available
 #: model:ir.model.fields,field_description:stock_secondary_unit.field_product_template__secondary_unit_qty_available
 #: model:ir.model.fields,field_description:stock_secondary_unit.field_stock_product_secondary_unit__secondary_unit_qty_available
 msgid "Quantity On Hand (2Unit)"
-msgstr "Cantidad a mano (2Ud.)"
+msgstr "在手数量（辅助单位）"
 
 #. module: stock_secondary_unit
 #: model:ir.model.fields,field_description:stock_secondary_unit.field_stock_move__secondary_uom_id
 #: model:ir.model.fields,field_description:stock_secondary_unit.field_stock_move_line__secondary_uom_id
 #: model:ir.model.fields,field_description:stock_secondary_unit.field_stock_secondary_unit_mixin__secondary_uom_id
-#, fuzzy
 msgid "Second unit"
-msgstr "Unidad Secundaria"
+msgstr "辅助单位"
 
 #. module: stock_secondary_unit
 #: model:ir.model.fields,field_description:stock_secondary_unit.field_product_product__stock_secondary_uom_id
 #: model:ir.model.fields,field_description:stock_secondary_unit.field_product_template__stock_secondary_uom_id
 msgid "Second unit for inventory"
-msgstr "Segunda unidad de medida para inventario"
+msgstr "库存辅助单位"
 
 #. module: stock_secondary_unit
 #: model:ir.model.fields,field_description:stock_secondary_unit.field_stock_move__secondary_uom_qty
 #: model:ir.model.fields,field_description:stock_secondary_unit.field_stock_move_line__secondary_uom_qty
 #: model:ir.model.fields,field_description:stock_secondary_unit.field_stock_secondary_unit_mixin__secondary_uom_qty
-#, fuzzy
 msgid "Secondary Qty"
-msgstr "Unidad Secundaria"
+msgstr "辅助单位数量"
 
 #. module: stock_secondary_unit
 #: model_terms:ir.ui.view,arch_db:stock_secondary_unit.view_template_property_form
 msgid "Secondary unit"
-msgstr "Unidad Secundaria"
+msgstr "辅助单位"
 
 #. module: stock_secondary_unit
 #: model:ir.model,name:stock_secondary_unit.model_stock_move
 msgid "Stock Move"
-msgstr ""
+msgstr "库存移动"
 
 #. module: stock_secondary_unit
 #: model:ir.model,name:stock_secondary_unit.model_stock_product_secondary_unit
-#, fuzzy
 msgid "Stock Product Secondary Unit"
-msgstr "Unidad Secundaria"
+msgstr "库存产品辅助单位"
 
 #. module: stock_secondary_unit
 #: model:ir.model,name:stock_secondary_unit.model_stock_secondary_unit_mixin
-#, fuzzy
 msgid "Stock Secondary Unit Mixin"
-msgstr "Unidad Secundaria"
-
-#~ msgid "On Hand (2unit)"
-#~ msgstr "A mano (2Ud.)"
-
-#~ msgid "Second Unit Quantity On Hand"
-#~ msgstr "Segunda unidad de medida por defecto"
+msgstr "库存辅助单位混合类"

--- a/stock_secondary_unit/models/stock_move.py
+++ b/stock_secondary_unit/models/stock_move.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo import api, fields, models
 from odoo.addons import decimal_precision as dp
-from odoo.tools.float_utils import float_round
+from odoo.tools.float_utils import float_compare, float_round
 
 
 class StockSecondaryUnitMixin(models.AbstractModel):
@@ -28,6 +28,52 @@ class StockMove(models.Model):
         res['secondary_uom_qty'] = self[-1:].secondary_uom_qty
         return res
 
+    @api.onchange('secondary_uom_id', 'secondary_uom_qty')
+    def onchange_secondary_uom(self):
+        if not self.secondary_uom_id:
+            return
+        factor = self.secondary_uom_id.factor * self.product_uom.factor
+
+        qty = float_round(
+            self.secondary_uom_qty * factor,
+            precision_rounding=self.product_uom.rounding
+        )
+        if float_compare(
+            self.product_uom_qty, qty, precision_rounding=self.product_uom.rounding
+        ) != 0:
+            self.product_uom_qty = qty
+
+    @api.onchange('product_uom_qty')
+    def onchange_secondary_unit_product_uom_qty(self):
+        if not self.secondary_uom_id:
+            return
+        factor = self.secondary_uom_id.factor * self.product_uom.factor
+
+        qty = float_round(
+            self.product_uom_qty / (factor or 1.0),
+            precision_rounding=self.secondary_uom_id.uom_id.rounding
+        )
+        if float_compare(
+            self.secondary_uom_qty,
+            qty,
+            precision_rounding=self.secondary_uom_id.uom_id.rounding
+        ) != 0:
+            self.secondary_uom_qty = qty
+
+    @api.onchange('product_uom')
+    def onchange_product_uom_for_secondary(self):
+        if not self.secondary_uom_id:
+            return
+        factor = self.product_uom.factor * self.secondary_uom_id.factor
+        qty = float_round(
+            self.product_uom_qty / (factor or 1.0),
+            precision_rounding=self.product_uom.rounding
+        )
+        if float_compare(
+            self.secondary_uom_qty, qty, precision_rounding=self.product_uom.rounding
+        ) != 0:
+            self.secondary_uom_qty = qty
+
 
 class StockMoveLine(models.Model):
     _inherit = ['stock.move.line', 'stock.secondary.unit.mixin']
@@ -43,10 +89,38 @@ class StockMoveLine(models.Model):
                 'product_uom_qty', vals.get('qty_done', 0.0))
             qty = float_round(
                 move_line_qty / (factor or 1.0),
-                precision_rounding=move.secondary_uom_id.uom_id.factor
+                precision_rounding=move.secondary_uom_id.uom_id.rounding
             )
             vals.update({
                 'secondary_uom_qty': qty,
                 'secondary_uom_id': move.secondary_uom_id.id,
             })
         return super().create(vals)
+
+    @api.multi
+    def write(self, vals):
+        move_lines_with_second_unit = self.filtered(
+            lambda ml: ml.move_id.secondary_uom_id)
+        res = super(StockMoveLine, self - move_lines_with_second_unit).write(
+            vals)
+        for rec in move_lines_with_second_unit:
+            move = rec.move_id
+            uom = rec.product_id.uom_id
+            factor = move.secondary_uom_id.factor * uom.factor
+            if 'product_uom_qty' in vals and vals['product_uom_qty'] == 0:
+                # The picking has been validated and product_uom_qty is
+                # reset to zero
+                move_line_qty = move.quantity_done
+            else:
+                move_line_qty = vals.get(
+                    'product_uom_qty', rec.product_uom_qty)
+            qty = float_round(
+                move_line_qty / (factor or 1.0),
+                precision_rounding=move.secondary_uom_id.uom_id.rounding
+            )
+            vals.update({
+                'secondary_uom_qty': qty,
+                'secondary_uom_id': move.secondary_uom_id.id,
+            })
+            res = super(StockMoveLine, rec).write(vals)
+        return res

--- a/stock_secondary_unit/readme/CONTRIBUTORS.rst
+++ b/stock_secondary_unit/readme/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
 * Carlos Dauden <carlos.dauden@tecnativa.com>
 * Sergio Teruel <sergio.teruel@tecnativa.com>
 * Kitti Upariphutthiphong <kittiu@ecosoft.co.th>
+* Giovanni Serra <giovanni@gslab.it>

--- a/stock_secondary_unit/static/description/index.html
+++ b/stock_secondary_unit/static/description/index.html
@@ -417,6 +417,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <li>Carlos Dauden &lt;<a class="reference external" href="mailto:carlos.dauden&#64;tecnativa.com">carlos.dauden&#64;tecnativa.com</a>&gt;</li>
 <li>Sergio Teruel &lt;<a class="reference external" href="mailto:sergio.teruel&#64;tecnativa.com">sergio.teruel&#64;tecnativa.com</a>&gt;</li>
 <li>Kitti Upariphutthiphong &lt;<a class="reference external" href="mailto:kittiu&#64;ecosoft.co.th">kittiu&#64;ecosoft.co.th</a>&gt;</li>
+<li>Giovanni Serra &lt;<a class="reference external" href="mailto:giovanni&#64;gslab.it">giovanni&#64;gslab.it</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/stock_secondary_unit/tests/test_stock_secondary_unit.py
+++ b/stock_secondary_unit/tests/test_stock_secondary_unit.py
@@ -1,8 +1,9 @@
 # Copyright 2018 Tecnativa - Sergio Teruel
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-from odoo.tests import SavepointCase
+from odoo.tests import Form, SavepointCase, tagged
 
 
+@tagged("-at_install", "post_install")
 class TestProductSecondaryUnit(SavepointCase):
     at_install = False
     post_install = True
@@ -10,8 +11,11 @@ class TestProductSecondaryUnit(SavepointCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.StockPicking = cls.env["stock.picking"]
+        cls.env.user.groups_id = [(4, cls.env.ref("uom.group_uom").id)]
         cls.warehouse = cls.env.ref('stock.warehouse0')
         cls.product_uom_kg = cls.env.ref('uom.product_uom_kgm')
+        cls.product_uom_ton = cls.env.ref("uom.product_uom_ton")
         cls.product_uom_unit = cls.env.ref('uom.product_uom_unit')
         ProductAttribute = cls.env['product.attribute']
         ProductAttributeValue = cls.env['product.attribute.value']
@@ -42,6 +46,12 @@ class TestProductSecondaryUnit(SavepointCase):
                     'uom_id': cls.product_uom_unit.id,
                     'factor': 0.9,
                 }),
+                (0, 0, {
+                    'code': 'C',
+                    'name': 'box 10',
+                    'uom_id': cls.product_uom_unit.id,
+                    'factor': 10,
+                }),
             ],
             'attribute_line_ids': [(0, 0, {
                 'attribute_id': cls.attribute_color.id,
@@ -67,6 +77,7 @@ class TestProductSecondaryUnit(SavepointCase):
             'location_id': cls.warehouse.lot_stock_id.id,
             'quantity': 10.0,
         })
+        cls.picking_type_out = cls.env.ref("stock.picking_type_out")
 
     def test_01_stock_secondary_unit_template(self):
         self.assertEqual(
@@ -110,3 +121,38 @@ class TestProductSecondaryUnit(SavepointCase):
             sum(delivery_order.move_line_ids.mapped('secondary_uom_qty'))
         self.assertEquals(uom_qty, 20.0)
         self.assertEquals(secondary_uom_qty, 40.0)
+        # After picking validation secondary_uom_qty not reset to zero
+        delivery_order.move_lines.quantity_done = 20.0
+        delivery_order.action_done()
+        secondary_uom_qty = \
+            sum(delivery_order.move_line_ids.mapped('secondary_uom_qty'))
+        self.assertEquals(secondary_uom_qty, 40.0)
+
+    def test_04_picking_secondary_unit(self):
+        product = self.product_template.product_variant_ids[0]
+        with Form(
+            self.StockPicking.with_context(
+                planned_picking=True,
+                default_picking_type_id=self.picking_type_out.id,
+            )
+        ) as picking_form:
+            with picking_form.move_ids_without_package.new() as move:
+                move.product_id = product
+                move.secondary_uom_qty = 1
+                move.secondary_uom_id = product.secondary_uom_ids[0]
+                self.assertEqual(move.product_uom_qty, 0.5)
+                move.secondary_uom_qty = 2
+                self.assertEqual(move.product_uom_qty, 1)
+                move.secondary_uom_id = product.secondary_uom_ids[1]
+                self.assertEqual(move.product_uom_qty, 1.8)
+                move.product_uom_qty = 5
+                self.assertAlmostEqual(move.secondary_uom_qty, 5.56, 2)
+                # Change uom from stock move line
+                move.secondary_uom_qty = 1
+                move.secondary_uom_id = product.secondary_uom_ids[2]
+                self.assertEqual(move.product_uom_qty, 10)
+                move.product_uom = self.product_uom_ton
+                self.assertAlmostEqual(move.secondary_uom_qty, 1000, 2)
+
+        picking = picking_form.save()
+        picking.action_confirm()

--- a/stock_secondary_unit/views/product_views.xml
+++ b/stock_secondary_unit/views/product_views.xml
@@ -32,7 +32,7 @@
                     class="oe_stat_button" icon="fa-building-o">
                     <div class="o_form_field o_stat_info">
                         <span class="o_stat_value"><field name="secondary_unit_qty_available" widget="statinfo" nolabel="1"/></span>
-                        <span class="o_stat_text"><field name="stock_secondary_uom_id"/></span>
+                        <span class="o_stat_text"><field name="stock_secondary_uom_id" readonly="1"/></span>
                     </div>
                 </button>
             </xpath>
@@ -45,14 +45,14 @@
                ref="stock.product_form_view_procurement_button"/>
         <field name="groups_id" eval="[(4, ref('uom.group_uom'))]"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='qty_available']/.." position="after">
+            <xpath expr="//field[@name='qty_available']/../../.." position="after">
                 <button class="oe_stat_button"
                        name="%(stock.product_open_quants)d"
                        icon="fa-building-o"
                        type="action" attrs="{'invisible':[('type', '!=', 'product')]}">
                     <div class="o_form_field o_stat_info">
                         <span class="o_stat_value"><field name="secondary_unit_qty_available" widget="statinfo" nolabel="1"/></span>
-                        <span class="o_stat_text"><field name="stock_secondary_uom_id"/></span>
+                        <span class="o_stat_text"><field name="stock_secondary_uom_id" readonly="1"/></span>
                     </div>
                 </button>
             </xpath>

--- a/stock_secondary_unit/views/stock_move_views.xml
+++ b/stock_secondary_unit/views/stock_move_views.xml
@@ -10,10 +10,11 @@
         <field name="groups_id" eval="[(4, ref('uom.group_uom'))]"/>
         <field name="arch" type="xml">
             <field name="product_uom_qty" position="before">
-                <field name="secondary_uom_qty"/>
+                <field name="secondary_uom_qty" readonly="1"/>
                 <field name="secondary_uom_id"
-                       domain="[('product_tmpl_id.product_variant_ids', 'in', [product_id])]"
-                       options="{'no_create': True}"/>
+                    attrs="{'readonly': ['|', ('product_uom_qty', '!=', 0.0), '&amp;', ('package_level_id', '!=', False), ('parent.picking_type_entire_packs', '=', True)]}"
+                    domain="[('product_tmpl_id.product_variant_ids', 'in', [product_id])]"
+                    options="{'no_create': True}"/>
             </field>
         </field>
     </record>

--- a/stock_secondary_unit/views/stock_picking_views.xml
+++ b/stock_secondary_unit/views/stock_picking_views.xml
@@ -10,14 +10,18 @@
         <field name="groups_id" eval="[(4, ref('uom.group_uom'))]"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='move_ids_without_package']/tree/field[@name='product_uom_qty']" position="before">
-                <field name="secondary_uom_qty"/>
+                <field name="secondary_uom_qty"
+                       attrs="{'column_invisible': ['&amp;',('parent.immediate_transfer', '=', True), ('parent.is_locked', '=', True)], 'readonly': [('is_initial_demand_editable', '=', False)]}" />
                 <field name="secondary_uom_id"
+                       attrs="{'readonly': [('state', '!=', 'draft'), ('additional', '=', False)]}"
                        domain="[('product_tmpl_id.product_variant_ids', 'in', [product_id])]"
                        options="{'no_create': True}"/>
             </xpath>
             <xpath expr="//field[@name='move_line_ids_without_package']/tree/field[@name='product_uom_qty']" position="before">
-                <field name="secondary_uom_qty"/>
+                <field name="secondary_uom_qty" readonly="1" />
                 <field name="secondary_uom_id"
+                       force_save="1"
+                       attrs="{'readonly': [('state', '!=', 'draft')]}"
                        domain="[('product_tmpl_id.product_variant_ids', 'in', [product_id])]"
                        options="{'no_create': True}"/>
             </xpath>


### PR DESCRIPTION
[2195](https://www.quartile.co/web#id=2195&model=project.task&view_type=form&menu_id=)

Just to apply the latest code, out of concern that the outdated code may cause some compatibility issue with other related modules.

One point to note is that with this update, secondary_uom_qty in stock.move.line becomes readonly, and for this reason, we are adding the secondary_uom_qty_done field to the model https://github.com/qrtl/hls-custom/pull/173/files#diff-471b13fc35883fd2e071ed84a04ce1c386afaa8fbac723f68ca0ac7ad849bb18R13-R18.
