### PR TITLE
st1 [2195][IMP] stock_secondary_unit

### DIFF
--- a/stock_secondary_unit/__manifest__.py
+++ b/stock_secondary_unit/__manifest__.py
@@ -3,7 +3,7 @@
 {
     'name': 'Stock Secondary Unit',
     'summary': 'Get product quantities in a secondary unit',
-    'version': '12.0.1.2.2',
+    'version': '12.0.1.2.3',
     'development_status': 'Beta',
     'category': 'stock',
     'website': 'https://github.com/OCA/stock-logistics-warehouse',

--- a/stock_secondary_unit/models/stock_move.py
+++ b/stock_secondary_unit/models/stock_move.py
@@ -74,6 +74,21 @@ class StockMove(models.Model):
         ) != 0:
             self.secondary_uom_qty = qty
 
+    def _action_confirm(self, merge=True, merge_into=False):
+        """Need this to update secondary_uom_qty of the moves for newly created
+        backorders.
+        """
+        moves = super()._action_confirm(merge=merge, merge_into=merge_into)
+        for move in moves:
+            move.onchange_secondary_unit_product_uom_qty()
+        return moves
+
+    def _action_done(self):
+        """Need this to update secondary_uom_qty of the partially processed moves."""
+        moves = super()._action_done()
+        for move in moves:
+            move.onchange_secondary_unit_product_uom_qty()
+        return moves
 
 class StockMoveLine(models.Model):
     _inherit = ['stock.move.line', 'stock.secondary.unit.mixin']

--- a/stock_secondary_unit/tests/test_stock_secondary_unit.py
+++ b/stock_secondary_unit/tests/test_stock_secondary_unit.py
@@ -121,12 +121,16 @@ class TestProductSecondaryUnit(SavepointCase):
             sum(delivery_order.move_line_ids.mapped('secondary_uom_qty'))
         self.assertEquals(uom_qty, 20.0)
         self.assertEquals(secondary_uom_qty, 40.0)
-        # After picking validation secondary_uom_qty not reset to zero
-        delivery_order.move_lines.quantity_done = 20.0
+        # After picking validation secondary_uom_qty reflects the processed qty
+        delivery_order.move_lines.quantity_done = 15.0
         delivery_order.action_done()
         secondary_uom_qty = \
             sum(delivery_order.move_line_ids.mapped('secondary_uom_qty'))
-        self.assertEquals(secondary_uom_qty, 40.0)
+        self.assertEquals(secondary_uom_qty, 30.0)
+        backorder = StockPicking.search([('backorder_id', '=', delivery_order.id)])
+        backorder_secondary_uom_qty = \
+            sum(backorder.move_line_ids.mapped('secondary_uom_qty'))
+        self.assertEquals(backorder_secondary_uom_qty, 10.0)
 
     def test_04_picking_secondary_unit(self):
         product = self.product_template.product_variant_ids[0]


### PR DESCRIPTION
[2195](https://www.quartile.co/web#id=2195&model=project.task&view_type=form&menu_id=)

Before this commit, secondary_uom_qty of stock.move would become inconsistent
with product_uom_qty when move was processed with a partial qty or backorder
was created. This commit fixes the issue.

This update should be reflected back to the OCA repo.