### PR TITLE
[6495][ADD] sale_automatic_workflow: Add translations

### DIFF
--- a/sale_automatic_workflow/i18n/ja.po
+++ b/sale_automatic_workflow/i18n/ja.po
@@ -1,27 +1,24 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * sale_automatic_workflow
+# 	* sale_automatic_workflow
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2016
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 18.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-12-31 01:43+0000\n"
-"PO-Revision-Date: 2016-12-31 01:43+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2016\n"
-"Language-Team: Japanese (https://www.transifex.com/oca/teams/23907/ja/)\n"
-"Language: ja\n"
+"POT-Creation-Date: 2026-03-31 02:59+0000\n"
+"PO-Revision-Date: 2026-03-31 02:59+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=1; plural=0;\n"
+"Plural-Forms: \n"
 
 #. module: sale_automatic_workflow
 #: model:ir.model.fields,field_description:sale_automatic_workflow.field_sale_order__all_qty_delivered
 msgid "All quantities delivered"
-msgstr ""
+msgstr "全数量配送済み"
 
 #. module: sale_automatic_workflow
 #: model:ir.actions.act_window,name:sale_automatic_workflow.act_sale_workflow_process_form
@@ -30,17 +27,42 @@ msgstr ""
 #: model:ir.ui.menu,name:sale_automatic_workflow.menu_sale_workflow_parent
 #: model_terms:ir.ui.view,arch_db:sale_automatic_workflow.sale_workflow_process_view_form
 msgid "Automatic Workflow"
-msgstr ""
+msgstr "自動ワークフロー"
+
+#. module: sale_automatic_workflow
+#: model:ir.filters,name:sale_automatic_workflow.automatic_workflow_create_invoice_filter
+msgid "Automatic Workflow Create Invoice Filter"
+msgstr "自動ワークフロー 請求書作成フィルタ"
 
 #. module: sale_automatic_workflow
 #: model:ir.actions.server,name:sale_automatic_workflow.ir_cron_automatic_workflow_job_ir_actions_server
 msgid "Automatic Workflow Job"
-msgstr ""
+msgstr "自動ワークフロージョブ"
+
+#. module: sale_automatic_workflow
+#: model:ir.filters,name:sale_automatic_workflow.automatic_workflow_order_filter
+msgid "Automatic Workflow Order Filter"
+msgstr "自動ワークフロー オーダフィルタ"
+
+#. module: sale_automatic_workflow
+#: model:ir.filters,name:sale_automatic_workflow.automatic_workflow_payment_filter
+msgid "Automatic Workflow Payment Filter"
+msgstr "自動ワークフロー 支払フィルタ"
+
+#. module: sale_automatic_workflow
+#: model:ir.filters,name:sale_automatic_workflow.automatic_workflow_sale_done_filter
+msgid "Automatic Workflow Sale Done Filter"
+msgstr "自動ワークフロー 販売完了フィルタ"
+
+#. module: sale_automatic_workflow
+#: model:ir.filters,name:sale_automatic_workflow.automatic_workflow_validate_invoice_filter
+msgid "Automatic Workflow Validate Invoice Filter"
+msgstr "自動ワークフロー 請求書検証フィルタ"
 
 #. module: sale_automatic_workflow
 #: model_terms:ir.ui.view,arch_db:sale_automatic_workflow.sale_order_view_form
 msgid "Automation Information"
-msgstr ""
+msgstr "自動ワークフロー情報"
 
 #. module: sale_automatic_workflow
 #: model:sale.workflow.process,warning:sale_automatic_workflow.automatic_validation
@@ -48,21 +70,22 @@ msgid ""
 "Be careful, if you save the order with this setting, it could be auto-"
 "confirmed, even if you are editing it."
 msgstr ""
+"注意: この設定で注文を保存すると、編集中でも自動的に確定される場合があります。"
 
 #. module: sale_automatic_workflow
 #: model:ir.model.fields,field_description:sale_automatic_workflow.field_sale_workflow_process__create_invoice
 msgid "Create Invoice"
-msgstr ""
+msgstr "請求書作成"
 
 #. module: sale_automatic_workflow
 #: model:ir.model.fields,field_description:sale_automatic_workflow.field_sale_workflow_process__create_invoice_filter_id
 msgid "Create Invoice Filter"
-msgstr ""
+msgstr "請求書作成フィルタ"
 
 #. module: sale_automatic_workflow
 #: model:ir.model.fields,field_description:sale_automatic_workflow.field_sale_workflow_process__create_invoice_filter_domain
 msgid "Create Invoice Filter Domain"
-msgstr ""
+msgstr "請求書作成フィルタドメイン"
 
 #. module: sale_automatic_workflow
 #: model:ir.model.fields,field_description:sale_automatic_workflow.field_automatic_workflow_job__create_uid
@@ -85,12 +108,12 @@ msgstr "表示名"
 #. module: sale_automatic_workflow
 #: model:ir.model.fields,field_description:sale_automatic_workflow.field_sale_workflow_process__payment_filter_domain
 msgid "Domain"
-msgstr ""
+msgstr "ドメイン"
 
 #. module: sale_automatic_workflow
 #: model:ir.model.fields,field_description:sale_automatic_workflow.field_sale_workflow_process__invoice_date_is_order_date
 msgid "Force Invoice Date"
-msgstr ""
+msgstr "請求日の強制"
 
 #. module: sale_automatic_workflow
 #: model:ir.model.fields,field_description:sale_automatic_workflow.field_automatic_workflow_job__id
@@ -102,7 +125,7 @@ msgstr "ID"
 #: model:ir.model.fields,help:sale_automatic_workflow.field_sale_workflow_process__warning
 msgid ""
 "If set, displays the message when an userselects the process on a sale order"
-msgstr ""
+msgstr "設定されている場合、ユーザが販売オーダでプロセスを選択した際にメッセージを表示します。"
 
 #. module: sale_automatic_workflow
 #: model:ir.model.fields,help:sale_automatic_workflow.field_sale_workflow_process__invoice_service_delivery
@@ -110,21 +133,23 @@ msgid ""
 "If this box is checked, when the first invoice is created The service sale "
 "order lines will be included and will be marked as delivered"
 msgstr ""
+"チェックすると、最初の請求書作成時にサービス販売オーダ明細が含まれ、"
+"配送済みとしてマークされます。"
 
 #. module: sale_automatic_workflow
 #: model_terms:ir.ui.view,arch_db:sale_automatic_workflow.sale_workflow_process_view_form
 msgid "Invoice Options"
-msgstr ""
+msgstr "請求書オプション"
 
 #. module: sale_automatic_workflow
 #: model:ir.model.fields,field_description:sale_automatic_workflow.field_sale_workflow_process__invoice_service_delivery
 msgid "Invoice Service on delivery"
-msgstr ""
+msgstr "配送時にサービスを請求する"
 
 #. module: sale_automatic_workflow
 #: model:ir.model,name:sale_automatic_workflow.model_account_move
 msgid "Journal Entry"
-msgstr ""
+msgstr "仕訳"
 
 #. module: sale_automatic_workflow
 #: model:ir.model.fields,field_description:sale_automatic_workflow.field_automatic_workflow_job__write_uid
@@ -146,111 +171,111 @@ msgstr "名称"
 #. module: sale_automatic_workflow
 #: model_terms:ir.ui.view,arch_db:sale_automatic_workflow.sale_workflow_process_view_form
 msgid "Order Configuration"
-msgstr ""
+msgstr "オーダ設定"
 
 #. module: sale_automatic_workflow
 #: model:ir.model.fields,field_description:sale_automatic_workflow.field_sale_workflow_process__order_filter_id
 msgid "Order Filter"
-msgstr ""
+msgstr "オーダフィルタ"
 
 #. module: sale_automatic_workflow
 #: model:ir.model.fields,field_description:sale_automatic_workflow.field_sale_workflow_process__order_filter_domain
 msgid "Order Filter Domain"
-msgstr ""
+msgstr "オーダフィルタドメイン"
 
 #. module: sale_automatic_workflow
 #: model:ir.model.fields,field_description:sale_automatic_workflow.field_sale_workflow_process__register_payment
 msgid "Register Payment"
-msgstr ""
+msgstr "支払登録"
 
 #. module: sale_automatic_workflow
 #: model:ir.model.fields,field_description:sale_automatic_workflow.field_sale_workflow_process__payment_filter_id
 msgid "Register Payment Invoice Filter"
-msgstr ""
+msgstr "支払登録 請求書フィルタ"
 
 #. module: sale_automatic_workflow
 #: model:ir.model.fields,field_description:sale_automatic_workflow.field_sale_workflow_process__sale_done
 msgid "Sale Done"
-msgstr ""
+msgstr "販売完了"
 
 #. module: sale_automatic_workflow
 #: model:ir.model.fields,field_description:sale_automatic_workflow.field_sale_workflow_process__sale_done_filter_id
 msgid "Sale Done Filter"
-msgstr ""
+msgstr "販売完了フィルタ"
 
 #. module: sale_automatic_workflow
 #: model:ir.model.fields,field_description:sale_automatic_workflow.field_sale_workflow_process__sale_done_filter_domain
 msgid "Sale Done Filter Domain"
-msgstr ""
+msgstr "販売完了フィルタドメイン"
 
 #. module: sale_automatic_workflow
 #: model:ir.model,name:sale_automatic_workflow.model_sale_workflow_process
 #: model:ir.model.fields,field_description:sale_automatic_workflow.field_account_bank_statement_line__workflow_process_id
 #: model:ir.model.fields,field_description:sale_automatic_workflow.field_account_move__workflow_process_id
 msgid "Sale Workflow Process"
-msgstr ""
+msgstr "販売ワークフロープロセス"
 
 #. module: sale_automatic_workflow
 #: model:ir.model.fields,field_description:sale_automatic_workflow.field_sale_workflow_process__property_journal_id
 msgid "Sales Journal"
-msgstr ""
+msgstr "売上仕訳帳"
 
 #. module: sale_automatic_workflow
 #: model:ir.model,name:sale_automatic_workflow.model_sale_order
 msgid "Sales Order"
-msgstr ""
+msgstr "販売オーダ"
 
 #. module: sale_automatic_workflow
 #: model:ir.model.fields,field_description:sale_automatic_workflow.field_sale_workflow_process__team_id
 msgid "Sales Team"
-msgstr ""
+msgstr "販売チーム"
 
 #. module: sale_automatic_workflow
 #: model:ir.model,name:sale_automatic_workflow.model_automatic_workflow_job
 msgid ""
 "Scheduler that will play automatically the validation of invoices, "
 "pickings..."
-msgstr ""
+msgstr "請求書や入出庫などの検証を自動的に実行するスケジューラ"
 
 #. module: sale_automatic_workflow
 #: model:ir.model.fields,field_description:sale_automatic_workflow.field_sale_workflow_process__send_order_confirmation_mail
 msgid "Send Order Confirmation Mail"
-msgstr ""
+msgstr "注文確認メールを送信"
 
 #. module: sale_automatic_workflow
 #: model:ir.model.fields,help:sale_automatic_workflow.field_sale_workflow_process__property_journal_id
 msgid "Set default journal to use on invoice"
-msgstr ""
+msgstr "請求書で使用するデフォルト仕訳帳を設定"
 
 #. module: sale_automatic_workflow
 #: model_terms:ir.ui.view,arch_db:sale_automatic_workflow.sale_workflow_process_view_form
 msgid "Set selection based on a search filter:"
-msgstr ""
+msgstr "検索フィルタに基づいて選択を設定:"
 
 #. module: sale_automatic_workflow
 #: model:ir.model.fields,field_description:sale_automatic_workflow.field_sale_workflow_process__validate_invoice
 msgid "Validate Invoice"
-msgstr ""
+msgstr "請求書を検証"
 
 #. module: sale_automatic_workflow
 #: model:ir.model.fields,field_description:sale_automatic_workflow.field_sale_workflow_process__validate_invoice_filter_id
 msgid "Validate Invoice Filter"
-msgstr ""
+msgstr "請求書検証フィルタ"
 
 #. module: sale_automatic_workflow
 #: model:ir.model.fields,field_description:sale_automatic_workflow.field_sale_workflow_process__validate_invoice_filter_domain
 msgid "Validate Invoice Filter Domain"
-msgstr ""
+msgstr "請求書検証フィルタドメイン"
 
 #. module: sale_automatic_workflow
 #: model:ir.model.fields,field_description:sale_automatic_workflow.field_sale_workflow_process__validate_order
 msgid "Validate Order"
-msgstr ""
+msgstr "オーダを検証"
 
 #. module: sale_automatic_workflow
 #: model:ir.model.fields,field_description:sale_automatic_workflow.field_sale_workflow_process__warning
 msgid "Warning Message"
-msgstr ""
+msgstr "警告メッセージ"
 
 #. module: sale_automatic_workflow
 #: model:ir.model.fields,help:sale_automatic_workflow.field_sale_workflow_process__send_order_confirmation_mail
@@ -258,25 +283,20 @@ msgid ""
 "When checked, after order confirmation, a confirmation email will be sent "
 "(if not already sent)."
 msgstr ""
+"チェックすると、注文確認後に確認メールが送信されます（まだ送信されていない場合）。"
 
 #. module: sale_automatic_workflow
 #: model:ir.model.fields,help:sale_automatic_workflow.field_sale_workflow_process__invoice_date_is_order_date
 msgid "When checked, the invoice date will be the same than the order's date"
-msgstr ""
+msgstr "チェックすると、請求日が注文日と同じになります。"
 
 #. module: sale_automatic_workflow
 #: model_terms:ir.ui.view,arch_db:sale_automatic_workflow.sale_workflow_process_view_form
 msgid "Workflow Options"
-msgstr ""
+msgstr "ワークフローオプション"
 
 #. module: sale_automatic_workflow
 #. odoo-python
 #: code:addons/sale_automatic_workflow/models/sale_order.py:0
 msgid "Workflow Warning"
-msgstr ""
-
-#~ msgid "Last Modified on"
-#~ msgstr "最終更新日"
-
-#~ msgid "Invoice"
-#~ msgstr "請求書"
+msgstr "ワークフロー警告"


### PR DESCRIPTION
[6495](https://www.quartile.co/web#id=6495&menu_id=505&cids=3&action=1457&model=project.task&view_type=form)

Add ja.po

### Translation notes
Translations are referenced from existing Odoo translations where available (odoo/base, odoo/sale, odoo/sales_team, odoo/point_of_sale, odoo/stock, odoo/account).

The following terms have no reference and are translated independently:
| msgid | msgstr |
|---|---|
| All quantities delivered | 全数量配送済み |
| Automatic Workflow | 自動ワークフロー |
| Automatic Workflow Create Invoice Filter | 自動ワークフロー 請求書作成フィルタ |
| Automatic Workflow Job | 自動ワークフロージョブ |
| Automatic Workflow Order Filter | 自動ワークフロー オーダフィルタ |
| Automatic Workflow Payment Filter | 自動ワークフロー 支払フィルタ |
| Automatic Workflow Sale Done Filter | 自動ワークフロー 販売完了フィルタ |
| Automatic Workflow Validate Invoice Filter | 自動ワークフロー 請求書検証フィルタ |
| Automation Information | 自動ワークフロー情報 |
| Be careful, if you save the order with this setting... | 注意: この設定で注文を保存すると、編集中でも自動的に確定される場合があります。 |
| Create Invoice Filter | 請求書作成フィルタ |
| Create Invoice Filter Domain | 請求書作成フィルタドメイン |
| Force Invoice Date | 請求日の強制 |
| If set, displays the message... | 設定されている場合、ユーザが販売オーダでプロセスを選択した際にメッセージを表示します。 |
| If this box is checked... | チェックすると、最初の請求書作成時にサービス販売オーダ明細が含まれ、配送済みとしてマークされます。 |
| Invoice Options | 請求書オプション |
| Invoice Service on delivery | 配送時にサービスを請求する |
| Order Configuration | オーダ設定 |
| Order Filter | オーダフィルタ |
| Order Filter Domain | オーダフィルタドメイン |
| Register Payment | 支払登録 |
| Register Payment Invoice Filter | 支払登録 請求書フィルタ |
| Sale Done | 販売完了 |
| Sale Done Filter | 販売完了フィルタ |
| Sale Done Filter Domain | 販売完了フィルタドメイン |
| Sale Workflow Process | 販売ワークフロープロセス |
| Scheduler that will play automatically... | 請求書や入出庫などの検証を自動的に実行するスケジューラ |
| Send Order Confirmation Mail | 注文確認メールを送信 |
| Set default journal to use on invoice | 請求書で使用するデフォルト仕訳帳を設定 |
| Set selection based on a search filter: | 検索フィルタに基づいて選択を設定: |
| Validate Invoice | 請求書を検証 |
| Validate Invoice Filter | 請求書検証フィルタ |
| Validate Invoice Filter Domain | 請求書検証フィルタドメイン |
| When checked, after order confirmation... | チェックすると、注文確認後に確認メールが送信されます（まだ送信されていない場合）。 |
| When checked, the invoice date... | チェックすると、請求日が注文日と同じになります。 |
| Workflow Options | ワークフローオプション |
| Workflow Warning | ワークフロー警告 |