### PR TITLE
[6786][FIX] l10n_jp_summary_invoice: fix issue when the company currency and billing currency are different

### DIFF
--- a/l10n_jp_summary_invoice/models/account_billing.py
+++ b/l10n_jp_summary_invoice/models/account_billing.py
@@ -172,7 +172,7 @@ class AccountBilling(models.Model):
         associated with billing lines.
         """
         self.ensure_one()
-        tax_amount_groups = self.env["account.move.line"].read_group(
+        tax_amount_groups_tuples = self.env["account.move.line"]._read_group(
             domain=[
                 ("move_id", "in", self.billing_line_ids.move_id.ids),
                 "|",
@@ -181,9 +181,16 @@ class AccountBilling(models.Model):
                 ("display_type", "=", "rounding"),
                 ("tax_repartition_line_id", "!=", False),
             ],
-            fields=["tax_group_id", "balance"],
             groupby=["tax_group_id"],
+            aggregates=["amount_currency:sum"],
         )
+        tax_amount_groups = [
+            {
+                "tax_group_id": (group.id, group.name),
+                "amount_currency": amount_sum,
+            }
+            for group, amount_sum in tax_amount_groups_tuples
+        ]
         return tax_amount_groups
 
     def _get_inv_line_account_id(self):
@@ -205,22 +212,23 @@ class AccountBilling(models.Model):
             for subtotal in tax_totals.get("subtotals", []):
                 for group in subtotal.get("tax_groups", []):
                     tax_group_id = group.get("id")
-                    tax_amount = group.get("tax_amount", 0.0)
+                    tax_amount = group.get("tax_amount_currency", 0.0)
                     tax_group_amount_dict[tax_group_id] = tax_amount * -1
             tax_amount_groups_invoices = rec._get_tax_amount_groups_from_invoices()
             tax_group_diff_dict = {}
             for tax_amount_group in tax_amount_groups_invoices:
                 tax_group_id = tax_amount_group["tax_group_id"][0]
-                tax_amount_invoices = tax_amount_group["balance"]
+                tax_amount_invoices = tax_amount_group["amount_currency"]
                 tax_amount_bill = tax_group_amount_dict.get(tax_group_id, 0)
                 tax_diff = tax_amount_invoices - tax_amount_bill
-                if tax_diff:
+                if not rec.currency_id.is_zero(tax_diff):
                     tax_group_diff_dict[tax_group_id] = tax_diff
             if not tax_group_diff_dict:
                 continue
             invoice_vals = {
                 "move_type": "out_invoice",
                 "partner_id": rec.partner_id.id,
+                "currency_id": rec.currency_id.id,
                 "date": rec.date,
                 "invoice_origin": rec.name,
                 "ref": f"Tax adjustment for {rec.name}",

--- a/l10n_jp_summary_invoice/tests/test_l10n_jp_summary_invoice.py
+++ b/l10n_jp_summary_invoice/tests/test_l10n_jp_summary_invoice.py
@@ -69,7 +69,13 @@ class TestSummaryInvoice(TransactionCase):
         )
 
     def _create_invoice(
-        self, amount, tax, move_type="out_invoice", bank=None, partner=None
+        self,
+        amount,
+        tax,
+        move_type="out_invoice",
+        bank=None,
+        partner=None,
+        currency_id=None,
     ):
         invoice = (
             self.env["account.move"]
@@ -78,6 +84,7 @@ class TestSummaryInvoice(TransactionCase):
                 {
                     "move_type": move_type,
                     "partner_id": (partner or self.partner).id,
+                    "currency_id": currency_id or self.company.currency_id.id,
                     "partner_bank_id": bank and bank.id,
                     "invoice_line_ids": [
                         Command.create(
@@ -102,7 +109,7 @@ class TestSummaryInvoice(TransactionCase):
         for subtotal in tax_totals.get("subtotals", []):
             for group in subtotal.get("tax_groups", []):
                 tax_group_id = group.get("id")
-                tax_amount = group.get("tax_amount", 0.0)
+                tax_amount = group.get("tax_amount_currency", 0.0)
                 tax_group_amount_dict[tax_group_id] = tax_amount * -1
         return round(tax_group_amount_dict.get(self.tax_10.tax_group_id.id, 0), 0)
 
@@ -261,3 +268,36 @@ class TestSummaryInvoice(TransactionCase):
         billing.action_cancel()
         self.assertFalse(inv1.billing_id)
         self.assertFalse(inv2.billing_id)
+
+    def test_check_tax_adjustment_with_currency_rounding_issue(self):
+        self.assertEqual(self.env.company.currency_id, self.env.ref("base.JPY"))
+        currency_usd = self.env.ref("base.USD")
+        currency_usd.active = True
+        self.env["res.currency.rate"].create(
+            {
+                "name": "2026-03-20",
+                "rate": 1 / 155.0,
+                "currency_id": currency_usd.id,
+                "company_id": self.company.id,
+            }
+        )
+        out_inv_1 = self._create_invoice(
+            100.10, self.tax_10, currency_id=currency_usd.id
+        )
+        out_inv_2 = self._create_invoice(
+            100.10, self.tax_10, currency_id=currency_usd.id
+        )
+        out_inv_3 = self._create_invoice(
+            100.10, self.tax_10, currency_id=currency_usd.id
+        )
+        self.assertEqual(out_inv_1.amount_tax, 10.01)
+        self.assertEqual(out_inv_2.amount_tax, 10.01)
+        self.assertEqual(out_inv_3.amount_tax, 10.01)
+        invoices = out_inv_1 + out_inv_2 + out_inv_3
+        action = invoices.action_create_billing()
+        billing = self.env["account.billing"].browse(action["res_id"])
+        self.assertEqual(billing.state, "draft")
+        self.assertEqual(billing.currency_id, currency_usd)
+        billing.with_company(self.company).validate_billing()
+        self.assertEqual(billing.state, "billed")
+        self.assertFalse(billing.tax_adjustment_entry_id)


### PR DESCRIPTION
[6786](https://www.quartile.co/web#menu_id=505&cids=3&action=1457&model=project.task&view_type=form&id=6786)

Cherry-pick of OCA/l10n-japan#113 (merged 2026-04-21).

When company currency differs from billing currency, comparing tax amounts
in company currency (via 'balance' and 'tax_amount' fields) causes
unnecessary tax adjustments — the diff is actually FX-rate variance, not a
tax shortfall, but the module records it as additional consumption tax.

Switching the comparison to billing currency (`amount_currency`,
`tax_amount_currency`) eliminates the false adjustment.

Upstream PR: https://github.com/OCA/l10n-japan/pull/113
Upstream commit: ddf4c06fb701f35be9426affe360b84613ceaf96

[6786](https://www.quartile.co/web#menu_id=505&cids=3&action=1457&model=project.task&view_type=form&id=6786)